### PR TITLE
Fix CLI outputs

### DIFF
--- a/cmd/temporal-crypto/main.go
+++ b/cmd/temporal-crypto/main.go
@@ -47,6 +47,41 @@ var commands = map[string]cmd.Cmd{
 			}
 		},
 	},
+	"encrypt": cmd.Cmd{
+		Blurb: "encrypt file using Temporal's encryption format",
+		Description: `Encrypts given files using passphrase set in TEMPORAL_PASSPHRASE. Encrypted 
+		files are saved in ./<filename>.encrypted. Multiple files can be provided as arguments.`,
+		Action: func(cfg config.TemporalConfig, args map[string]string) {
+			p := os.Getenv("TEMPORAL_PASSPHRASE")
+			if p == "" {
+				log.Fatal("no passphrase provided in TEMPORAL_PASSPHRASE")
+			}
+
+			decrypt := crypto.NewEncryptManager(p)
+			for i := 2; i < len(os.Args); i++ {
+				f, err := os.Open(os.Args[i])
+				if err != nil {
+					log.Fatal(err)
+				}
+				out, err := decrypt.Encrypt(f)
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				dir, err := os.Getwd()
+				if err != nil {
+					log.Fatal(err)
+				}
+
+				if err = ioutil.WriteFile(
+					filepath.Join(dir, filepath.Base(os.Args[i]))+".encrypted",
+					out, 0644,
+				); err != nil {
+					log.Fatal(err)
+				}
+			}
+		},
+	},
 }
 
 func main() {

--- a/cmd/temporal-crypto/main.go
+++ b/cmd/temporal-crypto/main.go
@@ -13,8 +13,9 @@ import (
 
 var commands = map[string]cmd.Cmd{
 	"decrypt": cmd.Cmd{
-		Blurb:       "decrypt file encrypted by Temporal",
-		Description: "Decrypts given files using passphrase set in TEMPORAL_PASSPHRASE. Decrypted files are saved in ./<filename>.decrypted",
+		Blurb: "decrypt file encrypted by Temporal",
+		Description: `Decrypts given files using passphrase set in TEMPORAL_PASSPHRASE. Decrypted 
+		files are saved in ./<filename>.decrypted. Multiple files can be provided as arguments.`,
 		Action: func(cfg config.TemporalConfig, args map[string]string) {
 			p := os.Getenv("TEMPORAL_PASSPHRASE")
 			if p == "" {
@@ -38,8 +39,9 @@ var commands = map[string]cmd.Cmd{
 				}
 
 				if err = ioutil.WriteFile(
-					filepath.Join(dir, filepath.Base(os.Args[i])),
-					out, 0644); err != nil {
+					filepath.Join(dir, filepath.Base(os.Args[i]))+".decrypted",
+					out, 0644,
+				); err != nil {
 					log.Fatal(err)
 				}
 			}


### PR DESCRIPTION
This PR corrects the naming of the decrypted output to be `<filename>.decrypted`. It also adds a new `encrypt` command.